### PR TITLE
Add `range` key

### DIFF
--- a/roles/os9_vlan/README.md
+++ b/roles/os9_vlan/README.md
@@ -30,9 +30,11 @@ Role variables
 | ``description``      | string          | Configures a single line description for the VLAN | os9 |
 | ``tagged_members``   | list         | Specifies the list of port members to be tagged to the corresponding VLAN (see ``tagged_members.*``) | os9 |
 | ``tagged_members.port`` | string | Specifies valid device interface names to be tagged for each VLAN | os9 |
+| ``tagged_members.range`` | string | Specifies valid device interface range to be tagged for each VLAN | os9 |
 | ``tagged_members.state`` | string: absent,present | Deletes the tagged association for the VLAN if set to absent | os9 |
 | ``untagged_members`` | list         | Specifies the list of port members to be untagged to the corresponding VLAN (see ``untagged_members.*``) | os9 |
 | ``untagged_members.port`` | string | Specifies valid device interface names to be untagged for each VLAN | os9 |
+| ``untagged_members.range`` | string | Specifies valid device interface range to be untagged for each VLAN | os9 |
 | ``untagged_members.state`` | string: absent,present | Deletes the untagged association for the VLAN if set to absent | os9 |
 | ``state``           | string: absent,present\*          | Deletes the VLAN corresponding to the ID if set to absent | os9 |
                                                                                                       
@@ -88,6 +90,8 @@ When `os9_cfg_generate` is set to true, the variable generates the configuration
               state: absent
           untagged_members:
             - port: fortyGigE 1/14
+              state: present
+            - port: fortyGigE 1/15-17,1/19-23,1/25
               state: present
           state: present
 

--- a/roles/os9_vlan/templates/os9_vlan.j2
+++ b/roles/os9_vlan/templates/os9_vlan.j2
@@ -17,6 +17,8 @@ os9_vlan:
             state: absent
           - port: fortyGigE 0/44
             state: present
+          - range: fortyGigE 0/12-15,0/17,0/19-21
+            state: present
         state: present
 #########################################}
 {% if os9_vlan is defined and os9_vlan %}
@@ -51,11 +53,19 @@ interface Vlan {{ vlan_id[1] }}
       {% endif %}
       {% if vlan_vars.untagged_members is defined %}
         {% for ports in vlan_vars.untagged_members %}
-          {% if ports.port is defined and ports.port %}
+          {% if ports.range is defined and ports.range %}
             {% if ports.state is defined and ports.state == "absent" %}
- no untagged {{ ports.port }}
+ no untagged {{ ports.range }}
             {% else %}
+ untagged {{ ports.range }}
+            {% endif %}
+          {% else %}
+            {% if ports.port is defined and ports.port %}
+              {% if ports.state is defined and ports.state == "absent" %}
+ no untagged {{ ports.port }}
+              {% else %}
  untagged {{ ports.port }}
+              {% endif %}
             {% endif %}
           {% endif %}
         {% endfor %}
@@ -63,11 +73,19 @@ interface Vlan {{ vlan_id[1] }}
 
       {% if vlan_vars.tagged_members is defined %}
         {% for ports in vlan_vars.tagged_members %}
-          {% if ports.port is defined and ports.port %}
+          {% if ports.range is defined and ports.range %}
             {% if ports.state is defined and ports.state == "absent" %}
- no tagged {{ ports.port }}
+ no tagged {{ ports.range }}
             {% else %}
+ tagged {{ ports.range }}
+            {% endif %}
+          {% else %}
+            {% if ports.port is defined and ports.port %}
+              {% if ports.state is defined and ports.state == "absent" %}
+ no tagged {{ ports.port }}
+              {% else %}
  tagged {{ ports.port }}
+              {% endif %}
             {% endif %}
           {% endif %}
         {% endfor %}


### PR DESCRIPTION
Use the `range` key under tagged or untagged members to expedite
tagging or untagging of multiple ports.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It is often the case that a range of ports need to be tagged or untagged in certain vlan.
With this commit we can specify a range of ports which removes the need to create a list item for every port.
It is still possible to add additional ports to the list.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`os9_vlan`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
For example
```
os9_vlan:
      default_vlan: true
      VLAN 1:
        name: "vlan2"
        description: "int-vlan"
        tagged_members:
          - port: fortyGigE 0/32
            state: present
          - port: fortyGigE 0/40
            state: absent
        untagged_members:
          - port: fortyGigE 0/41
            state: absent
          - port: fortyGigE 0/44
            state: present
          - range: GigabitEthernet 1/9-1/15,1/17,1/20-1/28
            state: present
          - port: fortyGigE 0/45
            state: present
        state: present
```
would generate

```
default-vlan disable

interface Vlan 1
 name vlan2
 description int-vlan 
 no untagged fortyGigE 0/41
 untagged fortyGigE 0/44
 untagged GigabitEthernet 1/9-1/15,1/17,1/20-1/28
 untagged fortyGigE 0/45

 tagged fortyGigE 0/32
 no tagged fortyGigE 0/40
```