### PR TITLE
Change `desc` to `description`

### DIFF
--- a/playbooks/clos_fabric_ebgp/host_vars/leaf1.yaml
+++ b/playbooks/clos_fabric_ebgp/host_vars/leaf1.yaml
@@ -11,7 +11,7 @@ os9_system:
         state: present
 os9_interface:
     TenGigabitEthernet 0/0:
-            desc: "Connected to Spine 1"
+            description: "Connected to Spine 1"
             mtu: 9216
             portmode:
             admin: up
@@ -20,7 +20,7 @@ os9_interface:
             ipv6_and_mask: 2001:100:1:1::2/64
             state_ipv6: present
     TenGigabitEthernet 0/1:
-            desc: "Connected to Spine 2"
+            description: "Connected to Spine 2"
             mtu: 9216
             portmode:
             admin: up

--- a/playbooks/clos_fabric_ebgp/host_vars/leaf2.yaml
+++ b/playbooks/clos_fabric_ebgp/host_vars/leaf2.yaml
@@ -12,7 +12,7 @@ os9_system:
         state: present
 os9_interface:
     TenGigabitEthernet 0/0:
-            desc: "Connected to Spine 1"
+            description: "Connected to Spine 1"
             mtu: 9216
             portmode:
             admin: up
@@ -21,7 +21,7 @@ os9_interface:
             ipv6_and_mask: 2001:100:1:11::2/64
             state_ipv6: present
     TenGigabitEthernet 0/1:
-            desc: "Connected to Spine 2"
+            description: "Connected to Spine 2"
             mtu: 9216
             portmode:
             admin: up

--- a/playbooks/clos_fabric_ebgp/host_vars/leaf3.yaml
+++ b/playbooks/clos_fabric_ebgp/host_vars/leaf3.yaml
@@ -12,7 +12,7 @@ os9_system:
         state: present
 os9_interface:
     TenGigabitEthernet 0/0:
-            desc: "Connected to Spine 1"
+            description: "Connected to Spine 1"
             mtu: 9216
             portmode:
             admin: up
@@ -21,7 +21,7 @@ os9_interface:
             ipv6_and_mask: 2001:100:1:21::2/64
             state_ipv6: present
     TenGigabitEthernet 0/1:
-            desc: "Connected to Spine 2"
+            description: "Connected to Spine 2"
             mtu: 9216
             portmode:
             admin: up

--- a/playbooks/clos_fabric_ebgp/host_vars/leaf4.yaml
+++ b/playbooks/clos_fabric_ebgp/host_vars/leaf4.yaml
@@ -12,7 +12,7 @@ os9_system:
         state: present
 os9_interface:
     TenGigabitEthernet 0/0:
-            desc: "Connected to Spine 1"
+            description: "Connected to Spine 1"
             mtu: 9216
             portmode:
             admin: up
@@ -21,7 +21,7 @@ os9_interface:
             ipv6_and_mask: 2001:100:1:31::2/64
             state_ipv6: present
     TenGigabitEthernet 0/1:
-            desc: "Connected to Spine 2"
+            description: "Connected to Spine 2"
             mtu: 9216
             portmode:
             admin: up

--- a/playbooks/clos_fabric_ebgp/host_vars/spine1.yaml
+++ b/playbooks/clos_fabric_ebgp/host_vars/spine1.yaml
@@ -6,7 +6,7 @@ spine_hostname: "spine-1"
 
 os9_interface:
     TenGigabitEthernet 0/2:
-            desc: "Connected to leaf 1"
+            description: "Connected to leaf 1"
             mtu: 9216
             portmode:
             admin: up
@@ -15,7 +15,7 @@ os9_interface:
             ipv6_and_mask: 2001:100:1:1::1/64
             state_ipv6: present
     TenGigabitEthernet 0/3:
-            desc: "Connected to leaf 2"
+            description: "Connected to leaf 2"
             mtu: 9216
             portmode:
             admin: up
@@ -24,7 +24,7 @@ os9_interface:
             ipv6_and_mask: 2001:100:1:21::1/64
             state_ipv6: present
     TenGigabitEthernet 0/4:
-            desc: "Connected to leaf 3"
+            description: "Connected to leaf 3"
             mtu: 9216
             portmode:
             admin: up
@@ -33,7 +33,7 @@ os9_interface:
             ipv6_and_mask: 2001:100:1:11::1/64
             state_ipv6: present
     TenGigabitEthernet 0/5:
-            desc: "Connected to leaf 4"
+            description: "Connected to leaf 4"
             mtu: 9216
             portmode:
             admin: up

--- a/playbooks/clos_fabric_ebgp/host_vars/spine2.yaml
+++ b/playbooks/clos_fabric_ebgp/host_vars/spine2.yaml
@@ -5,7 +5,7 @@ ansible_network_os: dellemc.os9.os9
 spine_hostname: "spine-2"
 os9_interface:
     TenGigabitEthernet 0/6:
-            desc: "Connected to leaf 1"
+            description: "Connected to leaf 1"
             mtu: 9216
             portmode:
             admin: up
@@ -14,7 +14,7 @@ os9_interface:
             ipv6_and_mask: 2001:100:2:1::1/64
             state_ipv6: present
     TenGigabitEthernet 0/7:
-            desc: "Connected to leaf 2"
+            description: "Connected to leaf 2"
             mtu: 9216
             portmode:
             admin: up
@@ -23,7 +23,7 @@ os9_interface:
             ipv6_and_mask: 2001:100:2:11::1/64
             state_ipv6: present
     TenGigabitEthernet 0/8:
-            desc: "Connected to leaf 3"
+            description: "Connected to leaf 3"
             mtu: 9216
             portmode:
             admin: up
@@ -32,7 +32,7 @@ os9_interface:
             ipv6_and_mask: 2001:100:2:21::1/64
             state_ipv6: present
     TenGigabitEthernet 0/9:
-            desc: "Connected to leaf 4"
+            description: "Connected to leaf 4"
             mtu: 9216
             portmode:
             admin: up

--- a/roles/os9_interface/README.md
+++ b/roles/os9_interface/README.md
@@ -24,7 +24,7 @@ Role variables
 
 | Key        | Type                      | Description                                             | Support               |
 |------------|---------------------------|---------------------------------------------------------|-----------------------|
-| ``desc``  | string         | Configures a single line interface description  | os9 |
+| ``description``  | string         | Configures a single line interface description  | os9 |
 | ``portmode`` | string | Configures port-mode according to the device type |  access and trunk, os9 (hybrid)  |
 | ``switchport`` | boolean: true,false\*  | Configures an interface in L2 mode |  os9 |
 | ``admin``      | string: up,down\*              | Configures the administrative state for the interface; configuring the value as administratively "up" enables the interface; configuring the value as administratively "down" disables the interface | os9 |
@@ -101,64 +101,64 @@ When `os9_cfg_generate` is set to true, the variable generates the configuration
     build_dir: ../temp/os9
 
     os9_interface:
-        TenGigabitEthernet 1/8:
-          desc: "Connected to Spine1"
-          portmode:
-          switchport: False
-          mtu: 2500
-          admin: up
-          auto_neg: true
-          speed: auto
-          duplex: full
-          keepalive: true
-          ipv6_and_mask: 2001:4898:5808:ffa2::5/126
-          suppress_ra : present
-          ip_type_dynamic: true
-          ip_and_mask: 192.168.23.22/24
-          class_vendor_identifier: present
-          option82: true
-          remote_id: hostname
-        fortyGigE 1/9:
-          desc: "Connected to Spine2"
-          switchport: False
-          mtu: 2500
-          admin: up
-          cr4_auto_neg: true
-          ip_and_mask: 192.168.234.20/31
-          ip_and_mask_secondary: "192.168.234.21/31"
-          secondary_ip_state: present
-          suppress_ra: absent
-          ip_type_dynamic: false
-          class_vendor_identifier: absent
-          option82: true
-          remote_id: hostname
-          ipv6_and_mask: 2001:4898:5808:ffa2::9/126
-          flowcontrol:
-            mode: "receive"
-            enable: "on" 
-            state: "present"
-         vlan 100:
-           mtu: 4096
-           admin: down
-           ip_and_mask:
-           ipv6_and_mask: 2002:4898:5408:faaf::1/64
-           suppress_ra: present
-           state_ipv6: absent
-           ip_helper:
-              - ip: 10.0.0.36
-                state: absent
-            ipv6_reachabletime: 600000
-         virtual-network 888:
-           vrf: "green"
-           desc: "virtual-network interface"
-           ip_and_mask: "172.17.17.251/24"
-           ip_virtual_gateway_ip: "172.17.17.1"
-           admin: up
-         vlan 20:
-           suppress_ra: absent
-           min_ra: 3
-           max_ra: 4
-           admin: up
+      TenGigabitEthernet 1/8:
+        description: "Connected to Spine1"
+        portmode:
+        switchport: False
+        mtu: 2500
+        admin: up
+        auto_neg: true
+        speed: auto
+        duplex: full
+        keepalive: true
+        ipv6_and_mask: 2001:4898:5808:ffa2::5/126
+        suppress_ra: present
+        ip_type_dynamic: true
+        ip_and_mask: 192.168.23.22/24
+        class_vendor_identifier: present
+        option82: true
+        remote_id: hostname
+      fortyGigE 1/9:
+        description: "Connected to Spine2"
+        switchport: False
+        mtu: 2500
+        admin: up
+        cr4_auto_neg: true
+        ip_and_mask: 192.168.234.20/31
+        ip_and_mask_secondary: "192.168.234.21/31"
+        secondary_ip_state: present
+        suppress_ra: absent
+        ip_type_dynamic: false
+        class_vendor_identifier: absent
+        option82: true
+        remote_id: hostname
+        ipv6_and_mask: 2001:4898:5808:ffa2::9/126
+        flowcontrol:
+          mode: "receive"
+          enable: "on"
+          state: "present"
+      vlan 100:
+        mtu: 4096
+        admin: down
+        ip_and_mask:
+        ipv6_and_mask: 2002:4898:5408:faaf::1/64
+        suppress_ra: present
+        state_ipv6: absent
+        ip_helper:
+          - ip: 10.0.0.36
+            state: absent
+        ipv6_reachabletime: 600000
+      virtual-network 888:
+        vrf: "green"
+        description: "virtual-network interface"
+        ip_and_mask: "172.17.17.251/24"
+        ip_virtual_gateway_ip: "172.17.17.1"
+        admin: up
+      vlan 20:
+        suppress_ra: absent
+        min_ra: 3
+        max_ra: 4
+        admin: up
 
 **Simple playbook to setup system — leaf.yaml**
 

--- a/roles/os9_interface/templates/os9_interface.j2
+++ b/roles/os9_interface/templates/os9_interface.j2
@@ -4,7 +4,7 @@ Purpose:
 Configure interface commands for os9 Devices.
 os9_interface:
     TenGigabitEthernet 1/36:
-            desc: "OS9 intf"
+            description: "OS9 intf"
             portmode: hybrid
             mtu: 2000
             switchport: False
@@ -58,12 +58,10 @@ no stack-unit {{ port[0] }} port {{ port[1] }} portmode {{ intf_vars.fanout }} n
 {% set port = intf[1].split('/') %}
   {% if (intf_vars.fanout is defined and not intf_vars.fanout) or (intf_vars.fanout is not defined)%}
 interface {{ key }}
-    {% if intf_vars.desc is defined %}
-      {% if intf_vars.desc %}
- description {{ intf_vars.desc }}
-      {% else %}
+    {% if intf_vars.description is defined and intf_vars.description %}
+ description {{ intf_vars.description }}
+    {% else %}
  no description
-      {% endif %}
     {% endif %}
   
     {% if intf_vars.portmode is defined %}

--- a/roles/os9_interface/tests/main.os9.yaml
+++ b/roles/os9_interface/tests/main.os9.yaml
@@ -3,7 +3,7 @@
 # Sample variables for OS9 device
 os9_interface:
     TenGigabitEthernet 1/3:
-            desc: "Connected to Spine1"
+            description: "Connected to Spine1"
             portmode: 
             switchport: False
             suppress_ra: present
@@ -20,7 +20,7 @@ os9_interface:
             option82: true
             remote_id: hostname
     fortyGigE 1/9:
-            desc: "Connected to Spine2"
+            description: "Connected to Spine2"
             switchport: False
             mtu: 2500    
             admin: up


### PR DESCRIPTION
Other roles such as os9_vlan, os9_acl and os9_vrf all use the key `description`.
This change makes sure it is in line with the other roles.

merge

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`os9_interface`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
