### PR TITLE
Change `admin` subkey of `neighbor` to `shutdown`

### DIFF
--- a/playbooks/clos_fabric_ebgp/group_vars/spine.yaml
+++ b/playbooks/clos_fabric_ebgp/group_vars/spine.yaml
@@ -18,32 +18,32 @@ os9_bgp:
     - type: ipv4
       remote_asn: "{{ bgp_neigh1_remote_asn }}"
       ip: "{{ bgp_neigh1_ip }}"
-      admin: up
+      shutdown: False
       state: present
     - type: ipv4
       remote_asn: "{{ bgp_neigh2_remote_asn }}"
       ip: "{{ bgp_neigh2_ip }}"
-      admin: up
+      shutdown: False
       state: present
     - type: ipv4
       remote_asn: "{{ bgp_neigh3_remote_asn }}"
       ip: "{{ bgp_neigh3_ip }}"
-      admin: up
+      shutdown: False
       state: present
     - type: ipv4
       remote_asn: "{{ bgp_neigh4_remote_asn }}"
       ip: "{{ bgp_neigh4_ip }}"
-      admin: up
+      shutdown: False
       state: present
     - type: ipv6
       remote_asn: "{{ bgp_neigh5_remote_asn }}"
       ip: "{{ bgp_neigh5_ip }}"
-      admin: up
+      shutdown: False
       state: present
     - type: ipv6
       remote_asn: "{{ bgp_neigh6_remote_asn }}"
       ip: "{{ bgp_neigh6_ip }}"
-      admin: up
+      shutdown: False
       address_family:
         - type: ipv4
           activate: false
@@ -55,10 +55,10 @@ os9_bgp:
     - type: ipv6
       remote_asn: "{{ bgp_neigh7_remote_asn }}"
       ip: "{{ bgp_neigh7_ip }}"
-      admin: up
+      shutdown: False
       state: present
     - type: ipv6
       remote_asn: "{{ bgp_neigh8_remote_asn }}"
       ip: "{{ bgp_neigh8_ip }}"
-      admin: up
+      shutdown: False
   state: present

--- a/playbooks/clos_fabric_ebgp/host_vars/leaf1.yaml
+++ b/playbooks/clos_fabric_ebgp/host_vars/leaf1.yaml
@@ -14,7 +14,7 @@ os9_interface:
             desc: "Connected to Spine 1"
             mtu: 9216
             portmode:
-            admin: up
+            shutdown: False
             switchport: False
             ip_and_mask: 100.1.1.2/24
             ipv6_and_mask: 2001:100:1:1::2/64
@@ -23,7 +23,7 @@ os9_interface:
             desc: "Connected to Spine 2"
             mtu: 9216
             portmode:
-            admin: up
+            shutdown: False
             switchport: False
             ip_and_mask: 100.2.1.2/24
             ipv6_and_mask: 2001:100:2:1::2/64
@@ -41,21 +41,21 @@ os9_bgp:
       - type: ipv4
         remote_asn: 64901
         ip: 100.1.1.1
-        admin: up
+        shutdown: False
         state: present
       - type: ipv4
         remote_asn: 64901
         ip: 100.2.1.1
-        admin: up
+        shutdown: False
         state: present
       - type: ipv6
         remote_asn: 64901
         ip: 2001:100:1:1::1
-        admin: up
+        shutdown: False
         state: present
       - type: ipv6
         remote_asn: 64901
         ip: 2001:100:2:1::1
-        admin: up
+        shutdown: False
         state: present
     state: present

--- a/playbooks/clos_fabric_ebgp/host_vars/leaf2.yaml
+++ b/playbooks/clos_fabric_ebgp/host_vars/leaf2.yaml
@@ -15,7 +15,7 @@ os9_interface:
             desc: "Connected to Spine 1"
             mtu: 9216
             portmode:
-            admin: up
+            shutdown: False
             switchport: False
             ip_and_mask: 100.1.17.2/24
             ipv6_and_mask: 2001:100:1:11::2/64
@@ -24,7 +24,7 @@ os9_interface:
             desc: "Connected to Spine 2"
             mtu: 9216
             portmode:
-            admin: up
+            shutdown: False
             switchport: False
             ip_and_mask: 100.2.17.2/24
             ipv6_and_mask: 2001:100:2:11::2/64
@@ -41,25 +41,25 @@ os9_bgp:
       - type: ipv4
         remote_asn: 64901
         ip: 100.1.18.1
-        admin: up
+        shutdown: False
         state: present
       - type: ipv4
         remote_asn: 64901
         ip: 100.1.17.1
-        admin: up
+        shutdown: False
         state: present
       - type: ipv4
         remote_asn: 64901
         ip: 100.2.17.1
-        admin: up
+        shutdown: False
         state: present
       - type: ipv6
         remote_asn: 64901
         ip: 2001:100:1:11::1
-        admin: up
+        shutdown: False
         state: present
       - type: ipv6
         remote_asn: 64901
         ip: 2001:100:2:11::1
-        admin: up
+        shutdown: False
     state: present

--- a/playbooks/clos_fabric_ebgp/host_vars/leaf3.yaml
+++ b/playbooks/clos_fabric_ebgp/host_vars/leaf3.yaml
@@ -15,7 +15,7 @@ os9_interface:
             desc: "Connected to Spine 1"
             mtu: 9216
             portmode:
-            admin: up
+            shutdown: False
             switchport: False
             ip_and_mask: 100.1.33.2/24
             ipv6_and_mask: 2001:100:1:21::2/64
@@ -24,7 +24,7 @@ os9_interface:
             desc: "Connected to Spine 2"
             mtu: 9216
             portmode:
-            admin: up
+            shutdown: False
             switchport: False
             ip_and_mask: 100.2.33.2/24
             ipv6_and_mask: 2001:100:2:21::2/64
@@ -41,25 +41,25 @@ os9_bgp:
       - type: ipv4
         remote_asn: 64901
         ip: 100.1.33.1
-        admin: up
+        shutdown: False
         state: present
       - type: ipv4
         remote_asn: 64901
         ip: 100.2.33.1
-        admin: up
+        shutdown: False
         state: present
       - type: ipv6
         remote_asn: 64901
         ip: 2001:100:1:21::1
-        admin: up
+        shutdown: False
         state: present
       - type: ipv6
         remote_asn: 64901
         ip: 2001:100:1:22::1
-        admin: up
+        shutdown: False
         state: present
       - type: ipv6
         remote_asn: 64901
         ip: 2001:100:2:21::1
-        admin: up
+        shutdown: False
     state: present

--- a/playbooks/clos_fabric_ebgp/host_vars/leaf4.yaml
+++ b/playbooks/clos_fabric_ebgp/host_vars/leaf4.yaml
@@ -15,7 +15,7 @@ os9_interface:
             desc: "Connected to Spine 1"
             mtu: 9216
             portmode:
-            admin: up
+            shutdown: False
             switchport: False
             ip_and_mask: 100.1.49.2/24
             ipv6_and_mask: 2001:100:1:31::2/64
@@ -24,7 +24,7 @@ os9_interface:
             desc: "Connected to Spine 2"
             mtu: 9216
             portmode:
-            admin: up
+            shutdown: False
             switchport: False
             ip_and_mask: 100.2.49.2/24
             ipv6_and_mask: 2001:100:2:31::2/64
@@ -42,20 +42,20 @@ os9_bgp:
       - type: ipv4
         remote_asn: 64901
         ip: 100.1.49.1
-        admin: up
+        shutdown: False
         state: present
       - type: ipv4
         remote_asn: 64901
         ip: 100.2.49.1
-        admin: up
+        shutdown: False
         state: present
       - type: ipv6
         remote_asn: 64901
         ip: 2001:100:1:31::1
-        admin: up
+        shutdown: False
         state: present
       - type: ipv6
         remote_asn: 64901
         ip: 2001:100:2:31::1
-        admin: up
+        shutdown: False
     state: present

--- a/playbooks/clos_fabric_ebgp/host_vars/spine1.yaml
+++ b/playbooks/clos_fabric_ebgp/host_vars/spine1.yaml
@@ -9,7 +9,7 @@ os9_interface:
             desc: "Connected to leaf 1"
             mtu: 9216
             portmode:
-            admin: up
+            shutdown: False
             switchport: False
             ip_and_mask: 100.1.1.1/24
             ipv6_and_mask: 2001:100:1:1::1/64
@@ -18,7 +18,7 @@ os9_interface:
             desc: "Connected to leaf 2"
             mtu: 9216
             portmode:
-            admin: up
+            shutdown: False
             switchport: False
             ip_and_mask: 100.1.33.1/24
             ipv6_and_mask: 2001:100:1:21::1/64
@@ -27,7 +27,7 @@ os9_interface:
             desc: "Connected to leaf 3"
             mtu: 9216
             portmode:
-            admin: up
+            shutdown: False
             switchport: False
             ip_and_mask: 100.1.17.1/24
             ipv6_and_mask: 2001:100:1:11::1/64
@@ -36,7 +36,7 @@ os9_interface:
             desc: "Connected to leaf 4"
             mtu: 9216
             portmode:
-            admin: up
+            shutdown: False
             switchport: False
             ip_and_mask: 100.1.49.1/24
             ipv6_and_mask: 2001:100:1:31::1/64

--- a/playbooks/clos_fabric_ebgp/host_vars/spine2.yaml
+++ b/playbooks/clos_fabric_ebgp/host_vars/spine2.yaml
@@ -8,7 +8,7 @@ os9_interface:
             desc: "Connected to leaf 1"
             mtu: 9216
             portmode:
-            admin: up
+            shutdown: False
             switchport: False
             ip_and_mask: 100.2.1.1/24
             ipv6_and_mask: 2001:100:2:1::1/64
@@ -17,7 +17,7 @@ os9_interface:
             desc: "Connected to leaf 2"
             mtu: 9216
             portmode:
-            admin: up
+            shutdown: False
             switchport: False
             ip_and_mask: 100.2.17.1/24
             ipv6_and_mask: 2001:100:2:11::1/64
@@ -26,7 +26,7 @@ os9_interface:
             desc: "Connected to leaf 3"
             mtu: 9216
             portmode:
-            admin: up
+            shutdown: False
             switchport: False
             ip_and_mask: 100.2.33.1/24
             ipv6_and_mask: 2001:100:2:21::1/64
@@ -35,7 +35,7 @@ os9_interface:
             desc: "Connected to leaf 4"
             mtu: 9216
             portmode:
-            admin: up
+            shutdown: False
             switchport: False
             ip_and_mask: 100.2.49.1/24
             ipv6_and_mask: 2001:100:2:31::1/64

--- a/roles/os9_bgp/README.md
+++ b/roles/os9_bgp/README.md
@@ -54,7 +54,7 @@ Role variables
 | ``distribute_list.in_state`` | string: absent,present\* | Deletes the filter at incoming packets if set to absent           | os9 |
 | ``distribute_list.out`` | string       | Configures the name of the prefix-list to filter outgoing packets   | os9 |
 | ``distribute_list.out_state`` | string: absent,present\* | Deletes the filter at outgoing packets if set to absent          | os9 |
-| ``neighbor.admin`` | string: up,down       | Configures the administrative state of the neighbor  | os9 |
+| ``neighbor.shutdown`` | boolean: true\*, false      | Configures the administrative state of the neighbor, by default it is shutdown state  | os9 |
 | ``neighbor.adv_interval`` | integer       | Configures the advertisement interval of the neighbor  | os9 |
 | ``neighbor.fall_over`` | string: absent,present       | Configures the session fall on peer-route loss  | os9 |
 | ``neighbor.sender_loop_detect`` | boolean: true,false         | Enables/disables the sender-side loop detect for neighbors | os9 |
@@ -154,7 +154,7 @@ When `os9_cfg_generate` is set to true, the variable generates the configuration
                in: aa
                in_state: present
             ebgp_multihop: 25
-            admin: up
+            shutdown: False
             state: present
           - ip: 2001:4898:5808:ffa2::1
             type: ipv6
@@ -167,7 +167,7 @@ When `os9_cfg_generate` is set to true, the variable generates the configuration
             src_loopback: 0
             src_loopback_state: present
             ebgp_multihop: 255
-            admin: up
+            shutdown: False
             state: present
           - name: peer1
             type: peergroup
@@ -199,7 +199,7 @@ When `os9_cfg_generate` is set to true, the variable generates the configuration
               - type: l2vpn
                 activate: true
                 state: present
-            admin: up
+            shutdown: False
             state: present
         redistribute:
           - route_type: static

--- a/roles/os9_bgp/templates/os9_bgp.j2
+++ b/roles/os9_bgp/templates/os9_bgp.j2
@@ -24,7 +24,7 @@ os9_bgp:
       - type: ipv4
         remote_asn: 11
         ip: 192.168.11.1
-        admin: up
+        shutdown: False
         sender_loop_detect: false
         src_loopback: 0
         src_loopback_state: present
@@ -47,7 +47,7 @@ os9_bgp:
         remote_asn: 6
         subnet: 10.128.3.192/27
         subnet_state: present
-        admin: up
+        shutdown: False
         default_originate: true
         sender_loop_detect: false
         src_loopback: 1
@@ -272,7 +272,7 @@ router bgp {{ bgp_vars.asn }}
                 {% endif %}
               {% endif %}
             {% endif %}
-            {% if neighbor.admin is defined and (neighbor.admin == "up" or neighbor.admin == "present") %}
+            {% if neighbor.shutdown is defined and neighbor.shutdown == False %}
  neighbor {{ tag_or_ip }} no shutdown
             {% else %}
  neighbor {{ tag_or_ip }} shutdown

--- a/roles/os9_bgp/tests/main.os9.yaml
+++ b/roles/os9_bgp/tests/main.os9.yaml
@@ -57,7 +57,7 @@
         distribute_list: 
            in: aa
            in_state: present
-        admin: up
+        shutdown: False
         state: present
 
       - ip: 192.168.13.3
@@ -85,7 +85,7 @@
         src_loopback: 0
         src_loopback_state: present
         ebgp_multihop: 255
-        admin: up
+        shutdown: False
         state: present
     redistribute:
       - route_type: static


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The subkey of `neighbor` in `os9_bgp` has been changed to shutdown as this reflects what is
actually being typed on the CLI and displayed in the config.
Also this key has been changed to a boolean type as there are only two
states this can take.
By default the state of the bgp neighbor is down so it need to be
explicitely be brought up.

This add to the changes of https://github.com/ansible-collections/dellemc.os9/pull/23
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
