### PR TITLE
Replace ansible.module_utils.six with Python stdlib equivalents

### DIFF
--- a/changelogs/fragments/remove-module-utils-six.yml
+++ b/changelogs/fragments/remove-module-utils-six.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Replace the deprecated ``ansible.module_utils.six`` compatibility shims with
+    their Python standard library equivalents. ``ansible.module_utils.six`` is
+    deprecated in ansible-core 2.21 and is scheduled for removal in 2.24.

--- a/plugins/modules/os9_command.py
+++ b/plugins/modules/os9_command.py
@@ -134,12 +134,11 @@ from ansible_collections.dellemc.os9.plugins.module_utils.network.os9 import run
 from ansible_collections.dellemc.os9.plugins.module_utils.network.os9 import os9_argument_spec, check_args
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import ComplexList
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.parsing import Conditional
-from ansible.module_utils.six import string_types
 
 
 def to_lines(stdout):
     for item in stdout:
-        if isinstance(item, string_types):
+        if isinstance(item, str):
             item = str(item).split('\n')
         yield item
 

--- a/plugins/modules/os9_facts.py
+++ b/plugins/modules/os9_facts.py
@@ -132,7 +132,6 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.os9.plugins.module_utils.network.os9 import run_commands
 from ansible_collections.dellemc.os9.plugins.module_utils.network.os9 import os9_argument_spec, check_args
-from ansible.module_utils.six import iteritems
 
 
 class FactsBase(object):
@@ -564,7 +563,7 @@ def main():
         facts.update(inst.facts)
 
     ansible_facts = dict()
-    for key, value in iteritems(facts):
+    for key, value in facts.items():
         key = 'ansible_net_%s' % key
         ansible_facts[key] = value
 


### PR DESCRIPTION
##### SUMMARY

`ansible.module_utils.six` is deprecated in ansible-core 2.21 and scheduled for removal in 2.24. Both uses have direct stdlib equivalents:

```python
-from ansible.module_utils.six import string_types   -> isinstance(item, str)
-from ansible.module_utils.six import iteritems      -> d.items()
```

On Python 3 `string_types` is `(str,)`, so `isinstance(x, str)` is equivalent, and `six.iteritems(d)` is `iter(d.items())`. The loop in `os9_facts.py` writes to a different dict than the one it iterates. A changelog fragment is included.

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

os9_command, os9_facts
